### PR TITLE
Fix definition extraction logic

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -151,4 +151,17 @@ function extractDefinitionsFromRendered(root) {
   let termIdx = headers.findIndex(h => /\b(term|item)\b/i.test(h));
   let defIdx  = headers.findIndex(h => /definition\/?guidance|definition|meaning|glossary|guidance/i.test(h));
   if (termIdx === -1 && headers.includes("Item")) termIdx = headers.indexOf("Item");
-  if (defIdx
+  if (defIdx === -1 && headers.includes("Meaning")) defIdx = headers.indexOf("Meaning");
+  if (termIdx === -1 || defIdx === -1) return defs;
+  rows.slice(1).forEach(r => {
+    const cells = [...r.querySelectorAll("th,td")];
+    const termCell = cells[termIdx];
+    const defCell  = cells[defIdx];
+    if (!termCell || !defCell) return;
+    const term = termCell.innerText.trim();
+    const def  = defCell.innerText.trim();
+    if (!term || !def || /^term$/i.test(term) || /^definition$/i.test(def)) return;
+    defs[term.toLowerCase()] = def;
+  });
+  return defs;
+}


### PR DESCRIPTION
## Summary
- reconstruct missing `extractDefinitionsFromRendered` logic
- ensure definition tables parsed and function closes properly

## Testing
- `node - <<'NODE'
class El {
  constructor(){
    this.innerHTML='';
    this.textContent='';
    this.style={};
    this.classList={add(){},remove(){},toggle(){},contains(){return false;}};
  }
  appendChild(){}
  addEventListener(){}
  querySelectorAll(){return[];}
}
const ids={fileList:new El(),filter:new El(),content:new El(),defsCount:new El(),toggleHighlight:new El(),tooltip:new El()};
const document={getElementById:id=>ids[id]||new El(),createElement:tag=>new El(),querySelectorAll:()=>[]};
global.document=document;global.location={search:""};global.history={replaceState(){}};
const fetch=async()=>({ok:true,json:async()=>[],text:async()=>""});
const marked={parse:x=>x};const DOMPurify={sanitize:x=>x};
global.fetch=fetch;global.marked=marked;global.DOMPurify=DOMPurify;
require('./docs/script.js');
console.log('init executed');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a861cfb8a08332a6b239706b8e5686