### PR TITLE
Declare light color scheme for docs

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -3,6 +3,7 @@
 }
 
 :root {
+  color-scheme: light;
   --bg: #ffffff;
   --panel: #f5f5f5;
   --ink: #222222;


### PR DESCRIPTION
## Summary
- ensure documentation uses a light color scheme

## Testing
- `python - <<'PY'
from playwright.sync_api import sync_playwright
import pathlib

with sync_playwright() as p:
    browser = p.chromium.launch(headless=True)
    page = browser.new_page()
    page.goto(pathlib.Path('docs/index.html').absolute().as_uri())
    color_scheme = page.evaluate("getComputedStyle(document.documentElement).colorScheme")
    search_bg = page.query_selector('input[type="search"]').evaluate("el => getComputedStyle(el).backgroundColor")
    print('color-scheme:', color_scheme)
    print('search input background:', search_bg)
    browser.close()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a861dca00c8332bbdc62568ae5cac0