### PR TITLE
Respect manifest titles in file list

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -45,7 +45,7 @@ function renderList(items) {
   for (const item of items) {
     const li = document.createElement("li");
     const btn = document.createElement("button");
-    btn.textContent = item.path.split("/").pop();
+    btn.textContent = item.title || item.path.split("/").pop();
     btn.title = item.path;
     btn.className = (current === item.path) ? "active" : "";
     btn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- Render list buttons using `item.title` with path basename as fallback
- Preserve full path in button `title` attribute for context

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8714332a08332b0556d5e6d1e4d7c