### PR TITLE
fix: fallback to rendered definitions

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -71,7 +71,10 @@ async function openFile(path) {
     const md = await fetchText(path);
     const html = DOMPurify.sanitize(marked.parse(md, { mangle:false, headerIds:true }));
     contentEl.innerHTML = html;
-    definitions = parseDefinitions(md) || extractDefinitionsFromRendered(contentEl);
+    definitions = parseDefinitions(md);
+    if (!Object.keys(definitions).length) {
+      definitions = extractDefinitionsFromRendered(contentEl);
+    }
     const n = Object.keys(definitions).length;
     defsCountEl.textContent = n ? `${n} definitions found` : "no definitions found";
     rehighlight();


### PR DESCRIPTION
## Summary
- ensure definitions are scraped from rendered content when parsing finds none

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a87133ede08332b19247d71f526cb8