### PR TITLE
Ensure each guidance note loads correctly

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -65,16 +65,19 @@ function renderList(items) {
   for (const item of items) {
     const li = document.createElement("li");
     const btn = document.createElement("button");
-    btn.textContent = item.title || item.path.split("/").pop();
-    btn.title = item.path;
-    btn.className = (current === item.path) ? "active" : "";
-    btn.addEventListener("click", () => {
-      current = item.path;
+    const path = item.path;
+    btn.textContent = item.title || path.split("/").pop();
+    btn.title = path;
+    btn.dataset.path = path;
+    btn.className = (current === path) ? "active" : "";
+    btn.addEventListener("click", e => {
+      const p = e.currentTarget.dataset.path;
+      current = p;
       [...listEl.querySelectorAll("button")].forEach(b => b.classList.remove("active"));
-      btn.classList.add("active");
-      openFile(item.path);
+      e.currentTarget.classList.add("active");
+      openFile(p);
       const url = new URL(location.href);
-      url.searchParams.set("src", item.path);
+      url.searchParams.set("src", p);
       history.replaceState(null, "", url.toString());
     });
     li.appendChild(btn);


### PR DESCRIPTION
## Summary
- avoid closure capture by storing path in each file-list button
- ensure clicking different notes loads the intended markdown file

## Testing
- `node --check docs/script.js`
- `node -e "const fs=require('fs');const path=require('path');const m=JSON.parse(fs.readFileSync('docs/manifest.json'));let missing=[];for (const it of m){if(!fs.existsSync(path.join('docs',it.path))) missing.push(it.path);}console.log('missing',missing.length);"`


------
https://chatgpt.com/codex/tasks/task_e_68a872c175288332a4ec95e8bd1be997