### PR TITLE
Handle manifest loading from docs path

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -71,7 +71,20 @@ async function openFile(path) {
 }
 
 function escapeHTML(s){return s.replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
-async function fetchJSON(u){const r=await fetch(u,{cache:"no-store"}); if(!r.ok) throw new Error(r.status); return r.json();}
+async function fetchJSON(u){
+  const tries = [u];
+  if (!u.startsWith("docs/")) tries.push(`docs/${u}`);
+  let lastErr;
+  for (const t of tries) {
+    try {
+      const r = await fetch(t,{cache:"no-store"});
+      if (r.ok) return await r.json();
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw lastErr || new Error(`failed to fetch ${u}`);
+}
 async function fetchText(u){
   const tries = [u];
   if (!u.startsWith("docs/")) tries.push(`docs/${u}`);


### PR DESCRIPTION
## Summary
- try `docs/manifest.json` when loading the file list so the viewer works regardless of current directory
- extend `fetchJSON` to mirror the fallback logic used by `fetchText`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a874b7c06c8332be8fede5edf0119c