### PR TITLE
Add dynamic glossary highlighting

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -5,6 +5,11 @@ const contentEl = document.getElementById("content");
 
 let manifest = [];
 let current = null;
+let definitions = {};
+
+const tooltip = document.createElement("div");
+tooltip.className = "definition-tooltip";
+document.body.appendChild(tooltip);
 
 init();
 
@@ -62,8 +67,10 @@ async function openFile(path) {
   contentEl.innerHTML = `<p class="muted">loading <code>${escapeHTML(path)}</code> …</p>`;
   try {
     const md = await fetchText(path);
+    definitions = parseDefinitions(md);
     const html = DOMPurify.sanitize(marked.parse(md, { mangle:false, headerIds:true }));
     contentEl.innerHTML = html;
+    highlightTerms();
   } catch (e) {
     contentEl.innerHTML = `<p style="color:#ff8383">failed to load <code>${escapeHTML(path)}</code></p>`;
     console.error(e);
@@ -98,4 +105,113 @@ async function fetchText(u){
     }
   }
   throw lastErr || new Error(`failed to fetch ${u}`);
+}
+
+function parseDefinitions(md) {
+  const defs = {};
+  md = md.replace(/\r\n/g, "\n");
+
+  const refRe = /^\[([^\]]+)\]:\s+(.+)$/gm;
+  let m;
+  while ((m = refRe.exec(md))) {
+    defs[m[1].trim().toLowerCase()] = m[2].trim();
+  }
+
+  const secRe = /^##\s+(?:\d+\s+)?(?:Definitions|Glossary)\s*$/gim;
+  let match;
+  while ((match = secRe.exec(md))) {
+    const start = match.index + match[0].length;
+    const rest = md.slice(start);
+    const next = rest.search(/\n##\s+/);
+    const block = rest.slice(0, next === -1 ? rest.length : next);
+
+    block.split(/\n/).forEach(line => {
+      const mLine = line.match(/\*\*(.+?)\*\*\s*[-–—:]\s*(.+)/);
+      if (mLine) {
+        defs[mLine[1].trim().toLowerCase()] = mLine[2].trim();
+      }
+    });
+
+    const rowRe = /^\|\s*([^|]+?)\s*\|\s*([^|]+?)\s*\|$/gm;
+    let row;
+    while ((row = rowRe.exec(block))) {
+      const term = row[1].trim();
+      const def = row[2].trim();
+      if (!term || /^term$/i.test(term) || /^[-\s]+$/.test(term)) continue;
+      if (!def || /^definition$/i.test(def) || /^[-\s]+$/.test(def)) continue;
+      defs[term.toLowerCase()] = def;
+    }
+  }
+
+  return defs;
+}
+
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function highlightTerms() {
+  const terms = Object.keys(definitions);
+  if (!terms.length) return;
+
+  const sorted = terms.sort((a, b) => b.length - a.length)
+    .map(t => escapeRegExp(t));
+  const pattern = new RegExp(`\\b(${sorted.join("|")})\\b`, "gi");
+
+  const walker = document.createTreeWalker(
+    document.getElementById("content"),
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode(node) {
+        if (!node.parentElement) return NodeFilter.FILTER_REJECT;
+        if (node.parentElement.closest("a, code, pre")) return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    }
+  );
+
+  const toProcess = [];
+  let n;
+  while ((n = walker.nextNode())) toProcess.push(n);
+
+  toProcess.forEach(node => {
+    const text = node.textContent;
+    pattern.lastIndex = 0;
+    let match;
+    let last = 0;
+    const frag = document.createDocumentFragment();
+
+    while ((match = pattern.exec(text))) {
+      const term = match[0];
+      if (match.index > last) {
+        frag.appendChild(document.createTextNode(text.slice(last, match.index)));
+      }
+      const span = document.createElement("span");
+      span.className = "def-term";
+      span.textContent = term;
+      span.dataset.definition = definitions[term.toLowerCase()];
+      span.addEventListener("mouseenter", showTooltip);
+      span.addEventListener("mouseleave", hideTooltip);
+      frag.appendChild(span);
+      last = match.index + term.length;
+    }
+    if (last < text.length) {
+      frag.appendChild(document.createTextNode(text.slice(last)));
+    }
+    if (frag.childNodes.length) {
+      node.parentNode.replaceChild(frag, node);
+    }
+  });
+}
+
+function showTooltip(e) {
+  tooltip.textContent = e.currentTarget.dataset.definition;
+  tooltip.style.display = "block";
+  const rect = e.currentTarget.getBoundingClientRect();
+  tooltip.style.top = `${window.scrollY + rect.bottom + 5}px`;
+  tooltip.style.left = `${window.scrollX + rect.left}px`;
+}
+
+function hideTooltip() {
+  tooltip.style.display = "none";
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -127,3 +127,21 @@ body {
   border: 1px solid #d0d7de;
   border-radius: 6px;
 }
+
+.def-term {
+  text-decoration: underline dotted;
+  cursor: help;
+}
+
+.definition-tooltip {
+  position: absolute;
+  background: var(--ink);
+  color: var(--bg);
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  max-width: 300px;
+  z-index: 1000;
+  display: none;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- Parse Definitions or Glossary sections in markdown and build term definition map
- Highlight matching terms in displayed document with tooltip hover definitions
- Add styles for definition terms and tooltip display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a878613a2c8332ba9ef03d0db2acd7