### PR TITLE
Support 'Glossary of Terms' sections for hover definitions

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -117,7 +117,7 @@ function parseDefinitions(md) {
     defs[m[1].trim().toLowerCase()] = m[2].trim();
   }
 
-  const secRe = /^##\s+(?:\d+\s+)?(?:Definitions|Glossary)\s*$/gim;
+  const secRe = /^##\s+(?:\d+\s+)?(?:Definitions|Glossary(?:\s+of\s+Terms)?)\s*$/gim;
   let match;
   while ((match = secRe.exec(md))) {
     const start = match.index + match[0].length;


### PR DESCRIPTION
## Summary
- broaden definition section regex to match `## Glossary of Terms` headings

## Testing
- `node --check docs/script.js`
- parsed sample "Glossary of Terms" markdown with `parseDefinitions` to confirm definitions are captured


------
https://chatgpt.com/codex/tasks/task_e_68a87c6b6fe883328f19a60af9b56357