### PR TITLE
feat: add collapsible sidebar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,6 +23,7 @@
     <section class="content">
       <article id="content" aria-live="polite">select a note from the list</article>
     </section>
+    <button id="sidebarToggle" class="sidebar-toggle" aria-label="toggle sidebar">❮</button>
   </main>
 
   <script src="script.js"></script>

--- a/docs/script.js
+++ b/docs/script.js
@@ -2,6 +2,13 @@
 const listEl = document.getElementById("fileList");
 const filterEl = document.getElementById("filter");
 const contentEl = document.getElementById("content");
+const layoutEl = document.querySelector(".layout");
+const toggleEl = document.getElementById("sidebarToggle");
+
+toggleEl.addEventListener("click", () => {
+  const collapsed = layoutEl.classList.toggle("collapsed");
+  toggleEl.textContent = collapsed ? "❯" : "❮";
+});
 
 let manifest = [];
 let current = null;

--- a/docs/style.css
+++ b/docs/style.css
@@ -61,6 +61,35 @@ body {
   display: grid;
   grid-template-columns: 280px 1fr;
   height: calc(100vh - 52px); /* header height */
+  position: relative;
+}
+
+.layout.collapsed {
+  grid-template-columns: 0 1fr;
+}
+
+.layout.collapsed .sidebar {
+  display: none;
+}
+
+.sidebar-toggle {
+  position: absolute;
+  top: 0.5rem;
+  left: 280px;
+  transform: translateX(-50%);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-left: none;
+  border-radius: 0 4px 4px 0;
+  cursor: pointer;
+  padding: 0.2rem 0.4rem;
+}
+
+.layout.collapsed .sidebar-toggle {
+  left: 0;
+  transform: none;
+  border-left: 1px solid var(--line);
+  border-right: none;
 }
 
 .sidebar {


### PR DESCRIPTION
## Summary
- allow sidebar containing GN list to collapse and expand via toggle arrow
- style layout for collapsed state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8870947a48332b89eccab64075ccd